### PR TITLE
fix: Remove :build qualification from boost

### DIFF
--- a/Formula/sunshine.rb
+++ b/Formula/sunshine.rb
@@ -10,8 +10,8 @@ class Sunshine < Formula
   license all_of: ["GPL-3.0", "BSD-3-Clause", "MIT"]
   head "https://github.com/LizardByte/Sunshine.git"
 
-  depends_on "boost" => :build
   depends_on "cmake" => :build
+  depends_on "boost"
   depends_on "curl"
   depends_on "ffmpeg"
   depends_on "node"


### PR DESCRIPTION
Testing, I'd had https://github.com/realqhc/homebrew/blob/7acc2666a9a0dd94f19a91071023973cfae43bed/Formula/sunshine.rb installed, then ran
```sh
brew uninstall --ignore-dependencies boost
sunshine
```

and observed:
```
% sunshine
dyld[91742]: Library not loaded: /opt/homebrew/opt/boost/lib/libboost_locale-mt.dylib
  Referenced from: <88A9359D-DA1A-3F27-A274-3EC23BB52971> /opt/homebrew/Cellar/sunshine/0.21.0/bin/sunshine-0.21.0.5bca024.dirty
  Reason: tried: '/opt/homebrew/opt/boost/lib/libboost_locale-mt.dylib' (no such file), '/System/Volumes/Preboot/Cryptexes/OS/opt/homebrew/opt/boost/lib/libboost_locale-mt.dylib' (no such file), '/opt/homebrew/opt/boost/lib/libboost_locale-mt.dylib' (no such file), '/usr/local/lib/libboost_locale-mt.dylib' (no such file), '/usr/lib/libboost_locale-mt.dylib' (no such file, not in dyld cache)
zsh: abort      sunshine
```

That it's actually a runtime dependency was revealed by `otool -L`:
```
% otool -L $(brew --prefix)/bin/sunshine
/opt/homebrew/bin/sunshine:
        /System/Library/Frameworks/ApplicationServices.framework/Versions/A/ApplicationServices (compatibility version 1.0.0, current version 61.0.0)
        /System/Library/Frameworks/AVFoundation.framework/Versions/A/AVFoundation (compatibility version 1.0.0, current version 2.0.0)
        /System/Library/Frameworks/CoreMedia.framework/Versions/A/CoreMedia (compatibility version 1.0.0, current version 1.0.0)
        /System/Library/Frameworks/CoreVideo.framework/Versions/A/CoreVideo (compatibility version 1.2.0, current version 1.5.0)
        /System/Library/Frameworks/VideoToolbox.framework/Versions/A/VideoToolbox (compatibility version 1.0.0, current version 1.0.0)
        /System/Library/Frameworks/Foundation.framework/Versions/C/Foundation (compatibility version 300.0.0, current version 1971.0.0)
        /System/Library/Frameworks/Cocoa.framework/Versions/A/Cocoa (compatibility version 1.0.0, current version 23.0.0)
        /opt/homebrew/opt/opus/lib/libopus.0.dylib (compatibility version 10.0.0, current version 10.0.0)
        /opt/homebrew/opt/boost/lib/libboost_locale-mt.dylib (compatibility version 0.0.0, current version 0.0.0)
        /opt/homebrew/opt/boost/lib/libboost_log-mt.dylib (compatibility version 0.0.0, current version 0.0.0)
        /opt/homebrew/opt/boost/lib/libboost_filesystem-mt.dylib (compatibility version 0.0.0, current version 0.0.0)
        /opt/homebrew/opt/boost/lib/libboost_program_options-mt.dylib (compatibility version 0.0.0, current version 0.0.0)
        /opt/homebrew/opt/openssl@3/lib/libssl.3.dylib (compatibility version 3.0.0, current version 3.0.0)
        /opt/homebrew/opt/openssl@3/lib/libcrypto.3.dylib (compatibility version 3.0.0, current version 3.0.0)
        /opt/homebrew/opt/curl/lib/libcurl.4.dylib (compatibility version 13.0.0, current version 13.0.0)
        /opt/homebrew/opt/boost/lib/libboost_atomic-mt.dylib (compatibility version 0.0.0, current version 0.0.0)
        /opt/homebrew/opt/boost/lib/libboost_regex-mt.dylib (compatibility version 0.0.0, current version 0.0.0)
        /opt/homebrew/opt/boost/lib/libboost_chrono-mt.dylib (compatibility version 0.0.0, current version 0.0.0)
        /opt/homebrew/opt/boost/lib/libboost_thread-mt.dylib (compatibility version 0.0.0, current version 0.0.0)
        /usr/lib/libc++.1.dylib (compatibility version 1.0.0, current version 1500.65.0)
        /usr/lib/libSystem.B.dylib (compatibility version 1.0.0, current version 1319.100.3)
        /System/Library/Frameworks/AVFAudio.framework/Versions/A/AVFAudio (compatibility version 1.0.0, current version 1.0.0)
        /System/Library/Frameworks/AppKit.framework/Versions/C/AppKit (compatibility version 45.0.0, current version 2299.50.120)
        /System/Library/Frameworks/CoreFoundation.framework/Versions/A/CoreFoundation (compatibility version 150.0.0, current version 1971.0.0)
        /System/Library/Frameworks/CoreGraphics.framework/Versions/A/CoreGraphics (compatibility version 64.0.0, current version 1690.5.4)
        /System/Library/Frameworks/CoreServices.framework/Versions/A/CoreServices (compatibility version 1.0.0, current version 1228.0.0)
        /usr/lib/libobjc.A.dylib (compatibility version 1.0.0, current version 228.0.0)
```